### PR TITLE
Bugfix #12

### DIFF
--- a/Prog/2010/Ncdb_2010_was15.sas
+++ b/Prog/2010/Ncdb_2010_was15.sas
@@ -50,7 +50,7 @@ run;
   sortby=geo2010,
   /** Metadata parameters **/
   restrictions=None,
-  revisions=%str(New file.),
+  revisions=%str(Added 65+ variables),
   /** File info parameters **/
   contents=Y,
   printobs=0,

--- a/Prog/2010/Ncdb_2010_was15.sas
+++ b/Prog/2010/Ncdb_2010_was15.sas
@@ -36,7 +36,7 @@ run;
 proc summary data=Ncdb_2010_was15_blk nway;
   class geo2010;
   id metro15 ucounty state;
-  var adult: child: max: min: mr: non: occ: shr: tot: trct: vac:;
+  var adult: child: old: max: min: mr: non: occ: shr: tot: trct: vac:;
   output sum=
     out=Ncdb_2010_was15 (drop=_freq_ _type_);
 run;


### PR DESCRIPTION
@NeighborhoodInfoDC/review it turns out I had to edit the Ncdb_2010_was15 program (the programs Peter mentioned were for the historic data in 2010 tracts and I needed 2010 data in 2010 tracts). I added the 65+ variable. There wasn't a nativity Q on the SF1 so nothing to add there. 