### PR TITLE
ward22 ncdb updates

### DIFF
--- a/Macros/Ncdb_2010_blk_mac.sas
+++ b/Macros/Ncdb_2010_blk_mac.sas
@@ -18,6 +18,7 @@
   03/20/17 RP Update for bridge park geography. 
   03/29/17 RP Added 65 years and older variable. 
   06/16/18 RP Update for cluster2017 geography.
+  05/11/22 EB Update for ward 22
 **************************************************************************/
 
 /** Macro Ncdb_2010_blk_mac - Start Definition **/
@@ -96,11 +97,13 @@
 		%Block10_to_cluster17( )
 
 		%Block10_to_stantoncommons( )
+
+		%Block10_to_ward22( )
         
       end;
       
       %let freqvars = &freqvars voterpre2012 anc2002 anc2012 city cluster2000 cluster_tr2000  
-                      psa2004 psa2012 geo2000 geo2010 ward2002 ward2012 eor zip bridgepk cluster2017 stantoncommons;
+                      psa2004 psa2012 geo2000 geo2010 ward2002 ward2012 eor zip bridgepk cluster2017 stantoncommons ward2022;
       
     %end;
     

--- a/Macros/Ncdb_2020_blk_mac.sas
+++ b/Macros/Ncdb_2020_blk_mac.sas
@@ -106,6 +106,8 @@
         %Block20_to_cluster17( )
 
         %Block20_to_stantoncommons( )
+
+		%Block20_to_ward22( )
         
       end;
       else do;
@@ -114,7 +116,7 @@
         
       end;
       
-      %let freqvars = &freqvars voterpre2012 anc2012 city cluster2017 psa2012 geo2020 ward2012 eor zip;
+      %let freqvars = &freqvars voterpre2012 anc2012 city cluster2017 psa2012 geo2020 ward2012 eor zip ward2022;
       
     %end;
     

--- a/Prog/2010/Ncdb_2010_sum_all.sas
+++ b/Prog/2010/Ncdb_2010_sum_all.sas
@@ -21,9 +21,10 @@
   03/22/17 RP Fixed order of datasteps to correct errors when running in batch mode. 
   03/16/18 RP Added cluster 2017 geography.
   05/22/18 RP Added stanton commons geography.
+  05/11/22 EB Added ward 2022 geography.
 **************************************************************************/
 
-%include "L:\SAS\Inc\StdLocal.sas";
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
 
 ** Define libraries **;
 %DCData_lib( NCDB )
@@ -174,6 +175,7 @@ quit;
 %Ncdb_sum_geo( geo=bridgepk )
 %Ncdb_sum_geo( geo=cluster2017 )
 %Ncdb_sum_geo( geo=stantoncommons )
+%Ncdb_sum_geo( geo=ward2022 )
 
 run;
 

--- a/Prog/2020/Ncdb_2020_sum_all.sas
+++ b/Prog/2020/Ncdb_2020_sum_all.sas
@@ -199,6 +199,7 @@ quit;
 %Ncdb_sum_geo( geo=geo2000 )
 %Ncdb_sum_geo( geo=geo2010 )
 %Ncdb_sum_geo( geo=geo2020 )
+%Ncdb_sum_geo( geo=ward2022 )
 
 run;
 

--- a/Prog/Ncdb_sum_all.sas
+++ b/Prog/Ncdb_sum_all.sas
@@ -17,9 +17,10 @@
 			   SAS1 from Alpha).
   03/16/18 RP  Updated for cluster 2017
   05/22/18 RP  Updated for Stanton Commons
+  05/11/22 EB  Updated fror ward22
 **************************************************************************/
 
-%include "L:\SAS\Inc\StdLocal.sas";
+%include "\\sas1\DCdata\SAS\Inc\StdLocal.sas";
 
 ** Define libraries **;
 %DCData_lib( Ncdb )


### PR DESCRIPTION
@rpitingolo I'm having errors "variable ward2022 not found" in the 2010 and 2020 ncdb_sum_all files.. looking at the log it seems like GEODLB and GEOFM are the correct (22 not 12) besides "NCDB_SUM_GEO GEOSUF _wd12" instead of wd_22. I'm not sure if that makes sense, but I'm checked the 2022 weights/programs and they are all fine, so was wondering if you had any idea about the issue? Sorry I thought this would be an easy addition..
